### PR TITLE
add jira and confluence renderers. resolves #8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "markrust"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markrust"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["guppy0130 <guppy0130@yahoo.com>"]
 edition = "2021"
 description = "Converts Markdown to Atlassian markup"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Convert from Markdown to Atlassian markup.
 
 ```console
 $ ./markrust -h
-markrust 2.0.0
+markrust 2.1.0
 guppy0130 <guppy0130@yahoo.com>
 Converts Markdown to Atlassian markup
 
@@ -18,11 +18,23 @@ ARGS:
     <OUTPUT>    FILE output, or empty for stdout
 
 OPTIONS:
-    -e, --editor                             Launch $EDITOR as input
-    -h, --help                               Print help information
-    -m, --modify-headers <MODIFY_HEADERS>    Add N to header level (can be negative) [default: 0]
-    -t, --toc                                Prepend TOC markup
-    -V, --version                            Print version information
+    -e, --editor
+            Launch $EDITOR as input
+
+    -h, --help
+            Print help information
+
+    -l, --language <LANGUAGE>
+            [default: confluence] [possible values: jira, confluence]
+
+    -m, --modify-headers <MODIFY_HEADERS>
+            Add N to header level (can be negative) [default: 0]
+
+    -t, --toc
+            Prepend TOC markup
+
+    -V, --version
+            Print version information
 ```
 
 ## Features

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,2 +1,0 @@
-/// The renderer for Atlassian markup
-pub mod jira;


### PR DESCRIPTION
* separate out confluence + jira renderers because of differences in
  handling code blocks
